### PR TITLE
Add Factory Project with Point initialization logic

### DIFF
--- a/DesignPatterns.Factory/DesignPatterns.Factory.csproj
+++ b/DesignPatterns.Factory/DesignPatterns.Factory.csproj
@@ -1,0 +1,10 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/DesignPatterns.Factory/Point/Point.cs
+++ b/DesignPatterns.Factory/Point/Point.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace DesignPatterns.Factory.Point;
+
+public enum CoordinateSystem
+{
+    Cartesian,
+    Polar
+}
+
+public class Point
+{
+    double x, y;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Point"/> class.
+    /// </summary>
+    /// <param name="a">x if cartesian, rho if polar</param>
+    /// <param name="b">y if cartesian, theta is polar</param>
+    /// <param name="system">The coordinate system to use. Cartesian if default</param>
+    /// <exception cref="ArgumentOutOfRangeException"></exception>
+    public Point(double a, double b, CoordinateSystem system = CoordinateSystem.Cartesian)
+    {
+        switch (system)
+        {
+            case CoordinateSystem.Cartesian:
+                this.x = a;
+                this.y = b;
+                break;
+            case CoordinateSystem.Polar:
+                this.x = a * Math.Cos(b);
+                this.y = a * Math.Sin(b);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(system), system, null);
+        }
+    }
+
+    public override string ToString()
+    {
+        return $"x: {x}, y: {y}";
+    }
+}

--- a/DesignPatterns.Factory/Point/PointProgram.cs
+++ b/DesignPatterns.Factory/Point/PointProgram.cs
@@ -1,0 +1,13 @@
+namespace DesignPatterns.Factory.Point;
+
+public static class PointProgram
+{
+    public static void Run(string[] args)
+    {
+        Console.WriteLine("Point Program");
+        var point = new Point(2, 3, CoordinateSystem.Cartesian);
+        Console.WriteLine(point);
+        var anotherPoint = new Point(2, 3, CoordinateSystem.Polar);
+        Console.WriteLine(anotherPoint);
+    }
+}

--- a/DesignPatterns.Factory/Program.cs
+++ b/DesignPatterns.Factory/Program.cs
@@ -1,9 +1,11 @@
-﻿namespace DesignPatterns.Factory;
+﻿using DesignPatterns.Factory.Point;
+
+namespace DesignPatterns.Factory;
 
 class Program
 {
     static void Main(string[] args)
     {
-        Console.WriteLine("Hello, World!");
+        PointProgram.Run(args);
     }
 }

--- a/DesignPatterns.Factory/Program.cs
+++ b/DesignPatterns.Factory/Program.cs
@@ -1,0 +1,9 @@
+﻿namespace DesignPatterns.Factory;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        Console.WriteLine("Hello, World!");
+    }
+}

--- a/dotnet.design.patterns.sln
+++ b/dotnet.design.patterns.sln
@@ -15,6 +15,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DependencyInversion", "Depe
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DesignPatterns.Builder", "DesignPatterns.Builder\DesignPatterns.Builder.csproj", "{3D53CE4D-9D32-471A-B3FD-A8BD31A90023}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DesignPatterns.Factory", "DesignPatterns.Factory\DesignPatterns.Factory.csproj", "{11CF9710-4736-4A10-93F6-C35FBC6A6798}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -48,5 +50,9 @@ Global
 		{3D53CE4D-9D32-471A-B3FD-A8BD31A90023}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3D53CE4D-9D32-471A-B3FD-A8BD31A90023}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3D53CE4D-9D32-471A-B3FD-A8BD31A90023}.Release|Any CPU.Build.0 = Release|Any CPU
+		{11CF9710-4736-4A10-93F6-C35FBC6A6798}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{11CF9710-4736-4A10-93F6-C35FBC6A6798}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{11CF9710-4736-4A10-93F6-C35FBC6A6798}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{11CF9710-4736-4A10-93F6-C35FBC6A6798}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Introduce a new Factory project that includes a Point class with an ambiguous initialization method for different coordinate systems. This change aims to provide a foundational design pattern for future development.